### PR TITLE
Fixed text overflow

### DIFF
--- a/src/taskpane/components/App.tsx
+++ b/src/taskpane/components/App.tsx
@@ -409,13 +409,15 @@ export default class App extends React.Component<AppProps, AppState> {
         display: "flex",
         justifyContent: "center",
         alignItems: "center",
+        whiteSpace: 'wrap',
       },
       link: {
-        // margin: "center",
-        width: "85px"
+        width: "85px",
+        lineHeight: "18px"
       },
       linkIsSelected: {
-        width: "85px"
+        width: "85px",
+        lineHeight: "18px"
       }
     };
 

--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -105,7 +105,3 @@ ul {
 .center.vertical {
   height: 100vh;
 }
-
-b {
-  font-weight: bold;
-}


### PR DESCRIPTION
Had to override the style properties of the component so I've fixed the text overflow for the tabs in 'Set-up' so it should look fine now for everyone. Let me know.