### PR TITLE
Yahoofinance fix

### DIFF
--- a/src/taskpane/sheets/population.ts
+++ b/src/taskpane/sheets/population.ts
@@ -386,13 +386,13 @@ export async function populateFinance() {
 
     //#region [rgba(20,50,20,0.5)] sample driver code
     let name = data.meta.symbol;
-	let utc_offset = data.meta.gmtoffset;
+    let utc_offset = data.meta.gmtoffset;
     let stocks_sample = [];
     data.timestamp.forEach((day, index) => {
       const date = new Date((day+utc_offset) * 1000);
       stocks_sample.push([
         //`${date.getDate()}/${date.getMonth()}/${date.getFullYear()}`,
-		date.toDateString(),
+	    date.toDateString(),
         data.indicators.adjclose[0].adjclose[index]
       ]);
     });
@@ -403,7 +403,6 @@ export async function populateFinance() {
     //#endregion
   }
 }
-
 	
 export async function populateTrends() {
   let Trends = {


### PR DESCRIPTION
Yahoo finance query exchanges in different timezones and reports each in UTC time. This however, causes the excel table too look abnormal and makes it seem wrong as some days of the week appear to be missing. Adjusting the dates back to local time of the exchanges makes more sense.